### PR TITLE
Made seti-monokai compatible with the latest versions of Atom

### DIFF
--- a/index.less
+++ b/index.less
@@ -1,11 +1,9 @@
 @import 'syntax-variables';
 
-.editor-colors {
+atom-text-editor, :host {
   background-color: @syntax-background-color;
   color: @syntax-text-color;
-}
 
-.editor {
   .invisible-character {
     color: @syntax-invisible-character-color;
   }


### PR DESCRIPTION
I made seti-monokai compatible with the latest versions of Atom by applying the changes from https://github.com/kevinsawicki/monokai. The various error messages (like "Use the `atom-text-editor` tag instead of the `editor-colors` class") shouldn't appear anymore with these changes.