### PR TITLE
Use "atom-text-editor" tag instead of "editor[-colors]" classes

### DIFF
--- a/index.less
+++ b/index.less
@@ -1,11 +1,9 @@
 @import 'syntax-variables';
 
-.editor-colors {
+:host, atom-text-editor {
   background-color: @syntax-background-color;
   color: @syntax-text-color;
-}
 
-.editor {
   .invisible-character {
     color: @syntax-invisible-character-color;
   }


### PR DESCRIPTION
This fixes the following deprecation warnings:

- "Use the atom-text-editor tag instead of the editor-colors class."

- "Target the selector :host, atom-text-editor instead of
  .editor-colors for shadow DOM support."

- "Use the atom-text-editor tag instead of the editor class."

- "Target the selector :host, atom-text-editor instead of
  .editor for shadow DOM support."

Closes joaoafrmartins/seti-monokai#7,
Closes joaoafrmartins/seti-monokai#8,
Closes joaoafrmartins/seti-monokai#9,
Closes joaoafrmartins/seti-monokai#10.